### PR TITLE
Qt.py invokes "from PyQt5.Qt import *"

### DIFF
--- a/go2streetview.py
+++ b/go2streetview.py
@@ -20,8 +20,8 @@
 """
 # Import the PyQt and QGIS libraries
 
-from PyQt5 import Qt, QtCore, QtWidgets, QtGui, QtWebKit, QtWebKitWidgets, QtXml, QtNetwork, uic
-from PyQt5.QtCore import QSettings, QTranslator, qVersion, QCoreApplication, Qt
+from PyQt5 import QtCore, QtWidgets, QtGui, QtWebKit, QtWebKitWidgets, QtXml, QtNetwork, uic
+from PyQt5.QtCore import QSettings, QTranslator, qVersion, QCoreApplication
 from qgis import core, utils, gui
 from qgis.utils import iface, qgsfunction, plugins
 from string import digits


### PR DESCRIPTION
that triggers importing QtBlutooth.dll that incompatible with Win 8.1
https://github.com/winpython/winpython/issues/592#issuecomment-408290186

This should fix #45
If Qt persists, user workaround is renaming existing Qt5Blutooth.dll

Reference implementation:
https://github.com/Codaone/DEXBot/pull/550